### PR TITLE
Removed GenPackage references from incquery-maven-compiler configuration

### DIFF
--- a/generator/org.eclipse.incquery.examples.cps.generator/pom.xml
+++ b/generator/org.eclipse.incquery.examples.cps.generator/pom.xml
@@ -59,15 +59,12 @@
 					<metamodels>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.deployment.DeploymentPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.deployment/model/deployment.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.cyberPhysicalSystem.CyberPhysicalSystemPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.model/model/model.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.traceability.TraceabilityPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.traceability/model/traceability.genmodel</genmodelUri>
 						</metamodel>
 					</metamodels>
 				</configuration>

--- a/queries/org.eclipse.incquery.examples.cps.queries/pom.xml
+++ b/queries/org.eclipse.incquery.examples.cps.queries/pom.xml
@@ -52,15 +52,12 @@
 					<metamodels>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.deployment.DeploymentPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.deployment/model/deployment.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.cyberPhysicalSystem.CyberPhysicalSystemPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.model/model/model.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.traceability.TraceabilityPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.traceability/model/traceability.genmodel</genmodelUri>
 						</metamodel>
 					</metamodels>
 				</configuration>

--- a/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.eiq/pom.xml
+++ b/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.eiq/pom.xml
@@ -59,15 +59,12 @@
 					<metamodels>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.deployment.DeploymentPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.deployment/model/deployment.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.cyberPhysicalSystem.CyberPhysicalSystemPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.model/model/model.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.traceability.TraceabilityPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.traceability/model/traceability.genmodel</genmodelUri>
 						</metamodel>
 					</metamodels>
 				</configuration>

--- a/transformations/org.eclipse.incquery.examples.cps.xform.m2m.incr.aggr/pom.xml
+++ b/transformations/org.eclipse.incquery.examples.cps.xform.m2m.incr.aggr/pom.xml
@@ -59,15 +59,12 @@
 					<metamodels>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.deployment.DeploymentPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.deployment/model/deployment.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.cyberPhysicalSystem.CyberPhysicalSystemPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.model/model/model.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.traceability.TraceabilityPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.traceability/model/traceability.genmodel</genmodelUri>
 						</metamodel>
 					</metamodels>
 				</configuration>

--- a/transformations/org.eclipse.incquery.examples.cps.xform.m2m.incr.expl/pom.xml
+++ b/transformations/org.eclipse.incquery.examples.cps.xform.m2m.incr.expl/pom.xml
@@ -59,15 +59,12 @@
 					<metamodels>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.deployment.DeploymentPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.deployment/model/deployment.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.cyberPhysicalSystem.CyberPhysicalSystemPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.model/model/model.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.traceability.TraceabilityPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.traceability/model/traceability.genmodel</genmodelUri>
 						</metamodel>
 					</metamodels>
 				</configuration>

--- a/transformations/org.eclipse.incquery.examples.cps.xform.m2m.incr.qrt/pom.xml
+++ b/transformations/org.eclipse.incquery.examples.cps.xform.m2m.incr.qrt/pom.xml
@@ -59,15 +59,12 @@
 					<metamodels>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.deployment.DeploymentPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.deployment/model/deployment.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.cyberPhysicalSystem.CyberPhysicalSystemPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.model/model/model.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.traceability.TraceabilityPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.traceability/model/traceability.genmodel</genmodelUri>
 						</metamodel>
 					</metamodels>
 				</configuration>

--- a/transformations/org.eclipse.incquery.examples.cps.xform.m2t.util/pom.xml
+++ b/transformations/org.eclipse.incquery.examples.cps.xform.m2t.util/pom.xml
@@ -59,15 +59,12 @@
 					<metamodels>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.deployment.DeploymentPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.deployment/model/deployment.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.cyberPhysicalSystem.CyberPhysicalSystemPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.model/model/model.genmodel</genmodelUri>
 						</metamodel>
 						<metamodel>
 							<packageClass>org.eclipse.incquery.examples.cps.traceability.TraceabilityPackage</packageClass>
-							<genmodelUri>../../domains/org.eclipse.incquery.examples.cps.traceability/model/traceability.genmodel</genmodelUri>
 						</metamodel>
 					</metamodels>
 				</configuration>


### PR DESCRIPTION
The updated EMF-IncQuery maven-builder does not require to reference GenPackages anymore. Removing the corresponding references.
