### PR TITLE
Fixed multiple wait application instance bug in M2M Xforms

### DIFF
--- a/tests/org.eclipse.incquery.examples.cps.xform.m2m.tests/src/org/eclipse/incquery/examples/cps/xform/m2m/tests/wrappers/BatchViatra.xtend
+++ b/tests/org.eclipse.incquery.examples.cps.xform.m2m.tests/src/org/eclipse/incquery/examples/cps/xform/m2m/tests/wrappers/BatchViatra.xtend
@@ -21,10 +21,14 @@ class BatchViatra extends CPSTransformationWrapper {
 	}
 	
 	override cleanupTransformation() {
+		if(xform != null){
+			xform.dispose
+		}
 		if(engine != null){
 			engine.dispose
 		}
 		xform = null
+		engine = null
 	}
 	
 }

--- a/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.eiq/src/org/eclipse/incquery/examples/cps/xform/m2m/batch/eiq/CPS2DeploymentBatchTransformationEiq.xtend
+++ b/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.eiq/src/org/eclipse/incquery/examples/cps/xform/m2m/batch/eiq/CPS2DeploymentBatchTransformationEiq.xtend
@@ -326,16 +326,37 @@ class CPS2DeploymentBatchTransformationEiq {
 	 * @param depTrigger
 	 *            The transition for which the trigger will be set.
 	 */
-	private def mapAction(BehaviorTransition depTrigger) {
-		trace('''Executing: mapAction(depTrigger = «depTrigger.name»)''')
+	private def mapAction(BehaviorTransition depSendTransition) {
+		trace('''Executing: mapAction(depTrigger = «depSendTransition.name»)''')
 		triggerTransformationPerformance.start
-		val cpsTransition = engine.cps2depTrace.getAllMatches(mapping, null, null, depTrigger).map[cpsElement].head as Transition
-		depTrigger.trigger += engine.triggerPair.getAllMatches(cpsTransition, null).filter [
-			val triggerApp = engine.cpsApplicationTransition.getAllValuesOfcpsApp(it.cpsTrigger).head as ApplicationInstance
-			val targetApp = engine.cpsApplicationTransition.getAllValuesOfcpsApp(it.cpsTarget).head as ApplicationInstance
-			engine.communicatingAppInstances.countMatches(triggerApp, targetApp) > 0
-		].map[engine.cps2depTrace.getAllValuesOfdepElement(mapping, null, cpsTarget)].flatten.filter(
-			BehaviorTransition)
+		
+		val cpsSendTransition = engine.cps2depTrace.getAllValuesOfcpsElement(mapping, null, depSendTransition).head as Transition
+		val cpsWaitTransitions = engine.triggerPair.getAllValuesOfcpsTarget(cpsSendTransition).filter(Transition)
+
+		val allApplicationTraces = engine.cps2depApplicationTrace.allValuesOftrace
+		val cpsSendAppTrace = allApplicationTraces.filter[
+			deploymentElements.filter(DeploymentApplication).head.behavior.transitions.contains(depSendTransition)
+		].filter(CPS2DeplyomentTrace).head
+		val cpsSendAppInstance = cpsSendAppTrace.cpsElements.head as ApplicationInstance
+				
+		
+		cpsWaitTransitions.forEach[cpsWaitTransition |
+			val cpsWaitAppInstances = engine.cpsApplicationTransition.getAllValuesOfcpsApp(cpsWaitTransition).filter(ApplicationInstance)
+			val communicatingWaitAppInstances = cpsWaitAppInstances.filter[
+				engine.communicatingAppInstances.hasMatch(cpsSendAppInstance, it)
+			]
+			communicatingWaitAppInstances.forEach[cpsWaitAppInstance |
+				val waitTransitionTrace = engine.cps2depTrace.getAllValuesOftrace(mapping, cpsWaitTransition, null).filter(CPS2DeplyomentTrace).head
+				val waitAppInstanceTrace = engine.cps2depTrace.getAllValuesOftrace(mapping, cpsWaitAppInstance, null).filter(CPS2DeplyomentTrace).head 
+				
+				val depWaitApp = waitAppInstanceTrace.deploymentElements.filter(DeploymentApplication).head
+				val depWaitTransition = waitTransitionTrace.deploymentElements.filter(BehaviorTransition).findFirst[
+					depWaitApp.behavior.transitions.contains(it)
+				]
+				depSendTransition.trigger += depWaitTransition
+			]
+		]
+
 		triggerTransformationPerformance.stop
 		trace('''Execution ended: mapAction''')
 	}

--- a/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.eiq/src/org/eclipse/incquery/examples/cps/xform/m2m/batch/eiq/CPS2DeploymentBatchTransformationEiq.xtend
+++ b/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.eiq/src/org/eclipse/incquery/examples/cps/xform/m2m/batch/eiq/CPS2DeploymentBatchTransformationEiq.xtend
@@ -333,15 +333,11 @@ class CPS2DeploymentBatchTransformationEiq {
 		val cpsSendTransition = engine.cps2depTrace.getAllValuesOfcpsElement(mapping, null, depSendTransition).head as Transition
 		val cpsWaitTransitions = engine.triggerPair.getAllValuesOfcpsTarget(cpsSendTransition).filter(Transition)
 
-		val allApplicationTraces = engine.cps2depApplicationTrace.allValuesOftrace
-		val cpsSendAppTrace = allApplicationTraces.filter[
-			deploymentElements.filter(DeploymentApplication).head.behavior.transitions.contains(depSendTransition)
-		].filter(CPS2DeplyomentTrace).head
-		val cpsSendAppInstance = cpsSendAppTrace.cpsElements.head as ApplicationInstance
+		val senderDepApp = depSendTransition.eContainer.eContainer as DeploymentApplication
+		val cpsSendAppInstance = engine.cps2depTrace.getAllValuesOfcpsElement(mapping, null, senderDepApp).head as ApplicationInstance
 				
-		
 		cpsWaitTransitions.forEach[cpsWaitTransition |
-			val cpsWaitAppInstances = engine.cpsApplicationTransition.getAllValuesOfcpsApp(cpsWaitTransition).filter(ApplicationInstance)
+			val cpsWaitAppInstances = engine.cpsApplicationTransition.getAllValuesOfcpsApp(cpsWaitTransition)
 			val communicatingWaitAppInstances = cpsWaitAppInstances.filter[
 				engine.communicatingAppInstances.hasMatch(cpsSendAppInstance, it)
 			]
@@ -351,7 +347,7 @@ class CPS2DeploymentBatchTransformationEiq {
 				
 				val depWaitApp = waitAppInstanceTrace.deploymentElements.filter(DeploymentApplication).head
 				val depWaitTransition = waitTransitionTrace.deploymentElements.filter(BehaviorTransition).findFirst[
-					depWaitApp.behavior.transitions.contains(it)
+					depWaitApp == it.eContainer.eContainer
 				]
 				depSendTransition.trigger += depWaitTransition
 			]

--- a/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.eiq/src/org/eclipse/incquery/examples/cps/xform/m2m/batch/eiq/queries/cpsXformM2M.eiq
+++ b/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.eiq/src/org/eclipse/incquery/examples/cps/xform/m2m/batch/eiq/queries/cpsXformM2M.eiq
@@ -46,7 +46,7 @@ pattern transitionAction(transition, appType, action) {
 	Transition.action(transition, action);
 }
 
-pattern cpsApplicationTransition(cpsApp, cpsTransition) {
+pattern cpsApplicationTransition(cpsApp : ApplicationInstance, cpsTransition : Transition) {
 	find cps2depTrace(_, _, cpsTransition, depTransition);
 	DeploymentApplication.behavior.transitions(depApp, depTransition);
 	find cps2depTrace(_, _, cpsApp, depApp);

--- a/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.eiq/src/org/eclipse/incquery/examples/cps/xform/m2m/batch/eiq/queries/cpsXformM2M.eiq
+++ b/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.eiq/src/org/eclipse/incquery/examples/cps/xform/m2m/batch/eiq/queries/cpsXformM2M.eiq
@@ -15,6 +15,11 @@ pattern cps2depTrace(cps2dep, trace, cpsElement, depElement) {
 	CPS2DeplyomentTrace.deploymentElements(trace, depElement);
 }
 
+pattern cps2depApplicationTrace(cps2dep, trace, cpsAppInstance, depApp) {
+	find cps2depTrace(cps2dep, trace, cpsAppInstance, depApp);
+	ApplicationInstance(cpsAppInstance);
+}
+
 pattern cpsBehaviorTrace(cpsBeh, trace) {
 	find cps2depTrace(_, trace, cpsBeh, _);
 	StateMachine(cpsBeh);

--- a/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.viatra/src/org/eclipse/incquery/examples/cps/xform/m2m/batch/viatra/CPS2DeploymentBatchViatra.xtend
+++ b/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.viatra/src/org/eclipse/incquery/examples/cps/xform/m2m/batch/viatra/CPS2DeploymentBatchViatra.xtend
@@ -39,8 +39,7 @@ class CPS2DeploymentBatchViatra {
 			this.mapping = cps2dep
 			this.engine = engine
 			
-			val ruleEngine = RuleEngines::createIncQueryRuleEngine(engine)
-			transformation = BatchTransformation::forRuleEngine(ruleEngine, AdvancedIncQueryEngine.from(engine))
+			transformation = BatchTransformation::forEngine(engine)
 			statements = new BatchTransformationStatements(transformation)
 			
 			debug("Preparing queries on engine.")
@@ -69,5 +68,14 @@ class CPS2DeploymentBatchViatra {
 		stateRule.fireAllCurrent
 		transitionRule.fireAllCurrent
 		actionRule.fireAllCurrent		
+	}
+	
+	
+	def dispose(){
+		if(transformation != null){
+			transformation.ruleEngine.dispose
+		}
+		transformation = null
+		return
 	}
 }

--- a/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.viatra/src/org/eclipse/incquery/examples/cps/xform/m2m/batch/viatra/rules/RuleProvider.xtend
+++ b/transformations/org.eclipse.incquery.examples.cps.xform.m2m.batch.viatra/src/org/eclipse/incquery/examples/cps/xform/m2m/batch/viatra/rules/RuleProvider.xtend
@@ -208,7 +208,7 @@ class RuleProvider {
 				
 				val depSendApp = sendAppInstanceTrace.deploymentElements.filter(DeploymentApplication).head
 				val depSendTransition = sendTransitionTrace.deploymentElements.filter(BehaviorTransition).findFirst[
-					depSendApp.behavior.transitions.contains(it)
+					depSendApp == it.eContainer.eContainer
 				]
 				
 				val waitTransitionTrace = getTraceForCPSElement(cpsWaitTransition)
@@ -216,7 +216,7 @@ class RuleProvider {
 				
 				val depWaitApp = waitAppInstanceTrace.deploymentElements.filter(DeploymentApplication).head
 				val depWaitTransition = waitTransitionTrace.deploymentElements.filter(BehaviorTransition).findFirst[
-					depWaitApp.behavior.transitions.contains(it)
+					depWaitApp == it.eContainer.eContainer
 				]
 				
 				depSendTransition.trigger += depWaitTransition

--- a/transformations/org.eclipse.incquery.examples.cps.xform.m2m.incr.aggr/src/org/eclipse/incquery/examples/cps/xform/m2m/incr/aggr/queries/cpsXformM2M.eiq
+++ b/transformations/org.eclipse.incquery.examples.cps.xform.m2m.incr.aggr/src/org/eclipse/incquery/examples/cps/xform/m2m/incr/aggr/queries/cpsXformM2M.eiq
@@ -58,6 +58,11 @@ pattern cps2depTrace(cps2dep, trace, cpsElement, depElement) {
 	CPS2DeplyomentTrace.deploymentElements(trace, depElement);
 }
 
+pattern cps2depApplicationTrace(cps2dep, trace, cpsAppInstance, depApp) {
+	find cps2depTrace(cps2dep, trace, cpsAppInstance, depApp);
+	ApplicationInstance(cpsAppInstance);
+}
+
 pattern cpsBehaviorTrace(cpsBeh, trace) {
 	find cps2depTrace(_, trace, cpsBeh, _);
 	StateMachine(cpsBeh);
@@ -72,11 +77,13 @@ pattern applicationInstance(appType, appInstance, host) {
 	ApplicationType.instances(appType, appInstance);
 	ApplicationInstance.allocatedTo(appInstance, host);
 }
-pattern cpsApplicationTransition(cpsApp, cpsTransition) {
+
+pattern cpsApplicationTransition(cpsApp : ApplicationInstance, cpsTransition : Transition) {
 	find cps2depTrace(_, _, cpsTransition, depTransition);
 	DeploymentApplication.behavior.transitions(depApp, depTransition);
 	find cps2depTrace(_, _, cpsApp, depApp);
 }
+
 pattern sendTransitionAppSignal(transition, app, signal) {
  	Transition.action(transition, action);
  	app == eval(SignalUtil.getAppId(action));


### PR DESCRIPTION
There was no test for checking whether triggers are correctly mapped for application types with multiple instances. The variants batch.eiq and incr.aggr failed the new test and were fixed.
