### PR TITLE
Viatra 1.3 migration

### DIFF
--- a/addons/org.eclipse.viatra.examples.cps.mwe2integration.example/META-INF/MANIFEST.MF
+++ b/addons/org.eclipse.viatra.examples.cps.mwe2integration.example/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.emf.mwe2.launch,
  org.eclipse.viatra.examples.cps.xform.serializer.javaio,
  org.eclipse.viatra.examples.cps.xform.m2m.incr.viatra;bundle-version="0.1.0",
  org.eclipse.xtend.lib;bundle-version="2.9.0",
- org.eclipse.viatra.integration.mwe2;bundle-version="[0.12.0,0.13.0)",
+ org.eclipse.viatra.integration.mwe2;bundle-version="[0.13.0,0.14.0)",
  org.eclipse.viatra.transformation.evm,
  org.eclipse.core.resources;bundle-version="3.10.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/addons/org.eclipse.viatra.examples.cps.view/META-INF/MANIFEST.MF
+++ b/addons/org.eclipse.viatra.examples.cps.view/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.viatra.examples.cps.model,
  org.eclipse.viatra.examples.cps.model.editor,
  org.eclipse.viatra.examples.cps.queries,
  com.google.guava;bundle-version="10.0.0",
- org.eclipse.viatra.addon.viewers.runtime;bundle-version="[0.12.0,0.13.0)",
- org.eclipse.viatra.addon.viewers.runtime.zest;bundle-version="[0.12.0,0.13.0)"
+ org.eclipse.viatra.addon.viewers.runtime;bundle-version="[0.13.0,0.14.0)",
+ org.eclipse.viatra.addon.viewers.runtime.zest;bundle-version="[0.13.0,0.14.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.apache.log4j;version="1.2.15"

--- a/releng/org.eclipse.viatra.examples.cps.setup/CPSExample.setup
+++ b/releng/org.eclipse.viatra.examples.cps.setup/CPSExample.setup
@@ -49,7 +49,8 @@
     <requirement
         name="org.eclipse.viatra.query.testing.sdk.feature.feature.group"/>
     <requirement
-        name="org.eclipse.viatra.addon.viewers.tooling.feature.feature.group"/>
+        name="org.eclipse.viatra.addon.viewers.tooling.feature.feature.group"
+        versionRange="[0.13.0,0.14.0)"/>
     <requirement
         name="org.eclipse.xtext.sdk.feature.group"
         versionRange="[2.9.0,2.10.0)"/>

--- a/releng/org.eclipse.viatra.examples.cps.setup/CPSExample.setup
+++ b/releng/org.eclipse.viatra.examples.cps.setup/CPSExample.setup
@@ -72,7 +72,7 @@
     <repository
         url="http://download.eclipse.org/viatra/dependency"/>
     <repository
-        url="https://hudson.eclipse.org/viatra/job/viatra-master/lastSuccessfulBuild/artifact/releng/org.eclipse.viatra.update/target/repository/"/>
+        url="http://download.eclipse.org/viatra/updates/integration"/>
   </setupTask>
   <setupTask
       xsi:type="setup.targlets:TargletTask">


### PR DESCRIPTION
I have changed version dependencies: stable project dependencies are set up as [1.3.0,2.0.0); incubation dependencies are set up as [0.13.0,0.14.0); a set of missing dependencies are also added.
